### PR TITLE
chore: update ios deployment target in project file to use ios 13

### DIFF
--- a/HackerNews.xcodeproj/project.pbxproj
+++ b/HackerNews.xcodeproj/project.pbxproj
@@ -531,7 +531,7 @@
 				COMPRESS_PNG_FILES = YES;
 				DEVELOPMENT_TEAM = P229S7564Q;
 				INFOPLIST_FILE = HackerNews/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 13;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = me.amitburst.hn;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -554,7 +554,7 @@
 				COMPRESS_PNG_FILES = YES;
 				DEVELOPMENT_TEAM = P229S7564Q;
 				INFOPLIST_FILE = HackerNews/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 13;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = me.amitburst.hn;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
# Description

* update ios deployment target in project file to use ios 13 (Note you should [use the workspace instead](https://github.com/amplitude/HackerNews?tab=readme-ov-file#getting-started), cleaning up for consistency)